### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python /home/runner/Game/startup.py"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # RPGpy
 A text- based RPG adventure written in python.
 NOTE: YOU MUST DOWNLOAD ALL OF THE GAME FILES, DOWNLOAD THE WHOLE FOLDER, AND USE startup.py TO START THE GAME. IT IS RECOMMENDED THAT THE GAME IS RUN IN IDLE.
+
+[![Run on Repl.it](https://repl.it/badge/github/BrendonOS/RPGpy)](https://repl.it/github/BrendonOS/RPGpy)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@joshwood/RPGpy).